### PR TITLE
Fix line height style issue

### DIFF
--- a/css/dark-theme.css
+++ b/css/dark-theme.css
@@ -2120,6 +2120,6 @@ table.release-table thead tr th a span {
 }
 
 /* extra line height in reviews */
-.review_comment_column .review_comment {
-	line-height: 1.4rem;
+.review_comment {
+  line-height: 1.4rem !important;
 }


### PR DESCRIPTION
Not sure what was going on - perhaps a hidden character? But the style wasn't being applied until I retyped it by hand.