### PR TITLE
Spread operator cleanup

### DIFF
--- a/js/extension/features/apply-highlights.js
+++ b/js/extension/features/apply-highlights.js
@@ -64,11 +64,11 @@ resourceLibrary.ready(() => {
   window.applyStyles = function applyStyles() {
 
     // Remove mobile clutter
-    [...document.querySelectorAll('.condition-label-mobile')].forEach(d => d.remove());
+    document.querySelectorAll('.condition-label-mobile').forEach(d => d.remove());
 
     // Media/sleeve conditions
-    const media = [...document.querySelectorAll('p.item_condition .condition-label-desktop:first-child + span')],
-          sleeves = [...document.querySelectorAll('span.item_sleeve_condition')];
+    const media = document.querySelectorAll('p.item_condition .condition-label-desktop:first-child + span'),
+          sleeves = document.querySelectorAll('span.item_sleeve_condition');
 
     addHighlights(media);
     addHighlights(sleeves);
@@ -98,7 +98,7 @@ resourceLibrary.ready(() => {
 
     window.applyStyles();
 
-    let pagination = [...document.querySelectorAll('ul.pagination_page_links a[class^="pagination_"]')];
+    let pagination = document.querySelectorAll('ul.pagination_page_links a[class^="pagination_"]');
 
     pagination.forEach(elem => {
 

--- a/js/extension/features/block-sellers.js
+++ b/js/extension/features/block-sellers.js
@@ -44,7 +44,7 @@ resourceLibrary.ready(() => {
 
   function addUiListeners(type) {
 
-    let pagination = [...document.querySelectorAll('ul.pagination_page_links a[class^="pagination_"]')];
+    let pagination = document.querySelectorAll('ul.pagination_page_links a[class^="pagination_"]');
 
     pagination.forEach(elem => {
 
@@ -69,7 +69,7 @@ resourceLibrary.ready(() => {
 
     blockList.list.forEach(seller => {
 
-      let sellerNames = [...document.querySelectorAll('td.seller_info ul li:first-child')];
+      let sellerNames = document.querySelectorAll('td.seller_info ul li:first-child');
 
       sellerNames.forEach(name => {
 

--- a/js/extension/features/blurry-image-fix.js
+++ b/js/extension/features/blurry-image-fix.js
@@ -29,8 +29,8 @@ resourceLibrary.ready(() => {
 
     let next = document.querySelector('.image_gallery_nav.image_gallery_next'),
         prev = document.querySelector('.image_gallery_nav.image_gallery_prev'),
-        slide = [...document.querySelectorAll('.image_gallery_slide img')],
-        thumb = [...document.querySelectorAll('.image_gallery_thumb')];
+        slide = document.querySelectorAll('.image_gallery_slide img'),
+        thumb = document.querySelectorAll('.image_gallery_thumb');
 
     // Next button
     next.addEventListener('click', ()=> setTimeout(checkForZoom, 0));
@@ -59,7 +59,7 @@ resourceLibrary.ready(() => {
 
     if ( isZoomed ) {
 
-      let img = [...document.querySelectorAll('.image_gallery_slide img.loaded')];
+      let img = document.querySelectorAll('.image_gallery_slide img.loaded');
 
       img.forEach(i => i.style.transform = 'translate(0, 0)');
 
@@ -74,7 +74,7 @@ resourceLibrary.ready(() => {
    */
   function unblur() {
 
-    let img = [...document.querySelectorAll('.image_gallery_slide img.loaded')],
+    let img = document.querySelectorAll('.image_gallery_slide img.loaded'),
         calc = 'calc(-50% + 0.5px)';
 
     img.forEach(i => {

--- a/js/extension/features/everlasting-marketplace-release-page.js
+++ b/js/extension/features/everlasting-marketplace-release-page.js
@@ -236,7 +236,7 @@ resourceLibrary.ready(() => {
     }
 
     // Hide standard means of page navigation
-    [...document.querySelectorAll('.pagination_page_links')].forEach(el => el.style.display = 'none');
+    document.querySelectorAll('.pagination_page_links').forEach(el => el.style.display = 'none');
 
     // ========================================================
     // UI Functionalty

--- a/js/extension/features/everlasting-marketplace.js
+++ b/js/extension/features/everlasting-marketplace.js
@@ -223,7 +223,7 @@ resourceLibrary.ready(() => {
     }
 
     // Hide standard means of page navigation
-    [...document.querySelectorAll('.pagination_page_links')].forEach(el => el.style.display = 'none');
+    document.querySelectorAll('.pagination_page_links').forEach(el => el.style.display = 'none');
 
     // ========================================================
     // UI Functionalty

--- a/js/extension/features/favorite-sellers.js
+++ b/js/extension/features/favorite-sellers.js
@@ -43,7 +43,7 @@ resourceLibrary.ready(() => {
 
   function addUiListeners() {
 
-    let pagination = [...document.querySelectorAll('ul.pagination_page_links a[class^="pagination_"]')];
+    let pagination = document.querySelectorAll('ul.pagination_page_links a[class^="pagination_"]');
 
     pagination.forEach(elem => {
 
@@ -66,7 +66,7 @@ resourceLibrary.ready(() => {
 
     favoriteList.list.forEach(seller => {
 
-      let sellerNames = [...document.querySelectorAll('td.seller_info ul li:first-child')];
+      let sellerNames = document.querySelectorAll('td.seller_info ul li:first-child');
 
       sellerNames.forEach(name => {
 

--- a/js/extension/features/seller-rep.js
+++ b/js/extension/features/seller-rep.js
@@ -81,7 +81,7 @@ resourceLibrary.ready(() => {
     // UI Functionality
     // ========================================================
 
-    let pagination = [...document.querySelectorAll('ul.pagination_page_links a[class^="pagination_"]')];
+    let pagination = document.querySelectorAll('ul.pagination_page_links a[class^="pagination_"]');
 
     pagination.forEach(elem => {
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "discogs-enhancer",
-  "version": "2.3.4",
+  "version": "2.3.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Not sure how I ended up in this habit but at some point I began wrapping all my `document.querySelectorAll` statements with the `spread operator`. I think I must have been using something like `map` and just forgot that `querySelectorAll` returns a `NodeList` with `forEach` support. At any rate, it's not necessary where I'm only using `forEach` so let's get rid of them!