### PR TITLE
Update page param when scrolling

### DIFF
--- a/js/extension/dependencies/resource-library.js
+++ b/js/extension/dependencies/resource-library.js
@@ -1003,6 +1003,20 @@
     unregistered: 'Please complete your Seller Settings before listing items for sale.',
 
     /**
+     * Updates the `page` query param in the URL
+     * @param {Number} pageNum - The page number
+     * @returns {undefined}
+     */
+    updatePageParam: function(pageNum) {
+      if ('URLSearchParams' in window) {
+        let searchParams = new URLSearchParams(window.location.search);
+        searchParams.set('page', pageNum);
+        let path = `${window.location.pathname}?${searchParams.toString()}`;
+        history.pushState(null, '', path);
+      }
+    },
+
+    /**
      * Hooks into `XMLHttpRequest` so that functions can be called
      * after a successful XHR.
      * @param {function} fn the callback function to execute

--- a/js/extension/features/everlasting-marketplace-release-page.js
+++ b/js/extension/features/everlasting-marketplace-release-page.js
@@ -190,7 +190,7 @@ resourceLibrary.ready(() => {
         if ( markup.match(/\S/) ) {
 
           appendMarketplaceResults(markup);
-
+          resourceLibrary.updatePageParam(pageNum);
         } else {
 
           loader.remove();

--- a/js/extension/features/everlasting-marketplace.js
+++ b/js/extension/features/everlasting-marketplace.js
@@ -165,7 +165,7 @@ resourceLibrary.ready(() => {
         if ( markup ) {
 
           appendMarketplaceResults(markup);
-
+          resourceLibrary.updatePageParam(pageNum);
         } else {
 
           loader.remove();


### PR DESCRIPTION
This PR will update the `page` query param in the URL when new pages are loaded using `everlasting marketplace`

Re issue: [Push history "page" search parameter in everlasting pages](https://github.com/salcido/discogs-enhancer/issues/31)

Updating `everlasting collection` will be fixed in a separate PR as I don't have 2500+ items in my collection.