### PR TITLE
Fix collection alert color

### DIFF
--- a/css/dark-theme.scss
+++ b/css/dark-theme.scss
@@ -1998,6 +1998,7 @@
       color: #454545 !important;
       line-height: 20px !important;
       i,
+      div,
       .alert-message-content div {
         background: #c5def7 !important;
         color: #454545 !important;


### PR DESCRIPTION
Fixes the Dark Theme color issue on the Collection alert.

<img width="981" alt="Screen Shot 2019-10-18 at 4 57 34 PM" src="https://user-images.githubusercontent.com/12960237/67134707-69a9ce00-f1c8-11e9-87cb-4fd9b1c21030.png">