### PR TITLE
Add style for search result current selection

### DIFF
--- a/css/dark-theme.scss
+++ b/css/dark-theme.scss
@@ -2650,6 +2650,11 @@
     }
   }
 
+  .result-item.current,
+  .no-results.current {
+    background: #454545 !important;
+  }
+
   /* Beta Tracks UI */
 
   .tracks-beta-banner {


### PR DESCRIPTION
When you search for things in the Edit Release page, selections are not highlighted when you mouse over or arrow down to a selection in the popup results box.  Here's a before/after of what this style looks like when applied:

## Before
![PR Before](https://user-images.githubusercontent.com/4356159/98748850-88a57000-2388-11eb-9c4c-fec4babee88a.PNG)

## After
![PR After](https://user-images.githubusercontent.com/4356159/98748885-9824b900-2388-11eb-91a5-07cb5aa80a1a.PNG)
