### PR TITLE
Add option to block user from wantlist message too

### DIFF
--- a/css/blocked-seller.css
+++ b/css/blocked-seller.css
@@ -3,6 +3,8 @@
 }
 
 .blocked-seller .seller_info strong a,
+.blocked-seller a,
+.blocked-seller a strong,
 .de-dark-theme .blocked-seller .seller_info strong a {
   color: #BF3A38 !important;
 }
@@ -18,8 +20,9 @@
 .blocked-seller .button.button-green,
 .blocked-seller .button.button-green span,
 .de-dark-theme .blocked-seller .button.button-green,
-.de-dark-theme .blocked-seller .button.button-green span {
-  background-image: linear-gradient(#BF3A38, #B33635);
+.de-dark-theme .blocked-seller .button.button-green span,
+.blocked-seller a.wantlist-button {
+  background-image: linear-gradient(#BF3A38, #B33635) !important;
   border-color: #982E2C !important;
   border-top-color: #902C2A !important;
   border-bottom-color: #842827 !important;

--- a/css/blocked-seller.css
+++ b/css/blocked-seller.css
@@ -3,8 +3,8 @@
 }
 
 .blocked-seller .seller_info strong a,
-.blocked-seller a,
-.blocked-seller a strong,
+.wantlist-card.blocked-seller a,
+.wantlist-card.blocked-seller a strong,
 .de-dark-theme .blocked-seller .seller_info strong a {
   color: #BF3A38 !important;
 }

--- a/js/extension/dependencies/resource-library.js
+++ b/js/extension/dependencies/resource-library.js
@@ -739,6 +739,7 @@
       'stats': '/stats/',
       'update': '/update',
       'videos': '/videos/',
+      'messages': '/messages/view/',
     },
 
     /**

--- a/js/extension/features/block-sellers.js
+++ b/js/extension/features/block-sellers.js
@@ -43,7 +43,7 @@ rl.ready(() => {
         clazz;
 
     if (querySelector === marketplaceQuerySelector) {
-      tag = 'a';
+      tag = 'li';
       clazz = '.shortcut_navigable';
     } else {
       tag = 'strong';

--- a/js/extension/features/block-sellers.js
+++ b/js/extension/features/block-sellers.js
@@ -20,10 +20,6 @@
  * specified user(s) (depending on the string value of `blockList.hide`) via CSS class.
  */
 
-const marketplaceQuerySelector =  'td.seller_info ul li:first-child a';
-
-const wantlistMessageQuerySelector = 'table.wantlist-card tbody tr:last-child td table tbody tr td table:last-child tbody tr td a strong';
-
 rl.ready(() => {
 
   // ========================================================
@@ -40,9 +36,19 @@ rl.ready(() => {
    * @return {function}
    */
 
-  window.blockSellers = function blockSellers(type, querySelector, tag, clazz) {
+  window.blockSellers = function blockSellers(type, querySelector) {
 
-    let _class = type === 'hide' ? 'hidden-seller' : 'blocked-seller';
+    let _class = type === 'hide' ? 'hidden-seller' : 'blocked-seller',
+        tag,
+        clazz;
+
+    if (querySelector === marketplaceQuerySelector) {
+      tag = 'a';
+      clazz = '.shortcut_navigable';
+    } else {
+      tag = 'strong';
+      clazz = '.wantlist-card';
+    }
 
     blockList.list.forEach(seller => {
 
@@ -70,7 +76,9 @@ rl.ready(() => {
   // DOM manipulation
   // ========================================================
   let blockList = rl.getPreference('blockList'),
-      type;
+      type,
+      marketplaceQuerySelector =  'td.seller_info ul li:first-child a',
+      wantlistMessageQuerySelector = 'table.wantlist-card tbody tr:last-child td table tbody tr td table:last-child tbody tr td a strong';
 
   if ( blockList ) {
 
@@ -82,11 +90,11 @@ rl.ready(() => {
 
         if ( rl.pageIs('allItems', 'seller', 'sellRelease', 'myWants') ) {
           type = 'hide';
-          window.blockSellers(type, marketplaceQuerySelector, 'a', '.shortcut_navigable');
+          window.blockSellers(type, marketplaceQuerySelector);
 
         } else if ( rl.pageIs('messages') ) {
           type = 'hide';
-          window.blockSellers(type, wantlistMessageQuerySelector, 'strong', '.wantlist-card');
+          window.blockSellers(type, wantlistMessageQuerySelector);
         }
         break;
 
@@ -96,11 +104,11 @@ rl.ready(() => {
 
         if ( rl.pageIs('myWants') ) {
           type = 'hide';
-          window.blockSellers(type, marketplaceQuerySelector, 'a', '.shortcut_navigable');
+          window.blockSellers(type, marketplaceQuerySelector);
 
         } else if ( rl.pageIs('allItems', 'seller', 'sellRelease') ) {
           type = 'tag';
-          window.blockSellers(type, wantlistMessageQuerySelector, 'strong', '.wantlist-card');
+          window.blockSellers(type, wantlistMessageQuerySelector);
         }
         break;
 
@@ -110,16 +118,16 @@ rl.ready(() => {
 
         if ( rl.pageIs('allItems', 'seller', 'sellRelease', 'myWants') ) {
           type = 'tag';
-          window.blockSellers(type, marketplaceQuerySelector, 'a', '.shortcut_navigable');
+          window.blockSellers(type, marketplaceQuerySelector);
 
         } else if ( rl.pageIs('messages') ) {
           type = 'tag';
-          window.blockSellers(type, wantlistMessageQuerySelector, 'strong', '.wantlist-card');
+          window.blockSellers(type, wantlistMessageQuerySelector);
         }
         break;
     }
 
-    rl.handlePaginationClicks(window.blockSellers, type, marketplaceQuerySelector, 'a', '.shortcut_navigable');
+    rl.handlePaginationClicks(window.blockSellers, type, marketplaceQuerySelector);
   }
 });
 /**

--- a/js/extension/features/block-sellers.js
+++ b/js/extension/features/block-sellers.js
@@ -20,6 +20,10 @@
  * specified user(s) (depending on the string value of `blockList.hide`) via CSS class.
  */
 
+const marketplaceQuerySelector =  'td.seller_info ul li:first-child a';
+
+const wantlistMessageQuerySelector = 'table.wantlist-card tbody tr:last-child td table tbody tr td table:last-child tbody tr td a strong';
+
 rl.ready(() => {
 
   // ========================================================
@@ -30,21 +34,24 @@ rl.ready(() => {
    *
    * @method blockSellers
    * @param {String} type Either 'hide' or 'tag'
+   * @param {String} querySelector Either 'marketplaceQuerySelector' or 'wantlistMessageQuerySelector' const
+   * @param {String} tag Either 'a' (anchor) or 'strong' tag
+   * @param {String} clazz Either 'shortcut_navigable' (marketplace) or 'wantlist-card' (wantlist message)
    * @return {function}
    */
 
-  window.blockSellers = function blockSellers(type) {
+  window.blockSellers = function blockSellers(type, querySelector, tag, clazz) {
 
     let _class = type === 'hide' ? 'hidden-seller' : 'blocked-seller';
 
     blockList.list.forEach(seller => {
 
-      let sellerNames = document.querySelectorAll('td.seller_info ul li:first-child a');
+      let sellerNames = document.querySelectorAll(querySelector);
 
       sellerNames.forEach(name => {
 
         if ( name.textContent.trim() === seller
-             && !name.closest('li').querySelector('.de-blocked-seller-icon') ) {
+          && !name.closest(tag).querySelector('.de-blocked-seller-icon') ) {
 
           let icon = document.createElement('span');
           icon.className = 'de-blocked-seller-icon needs_delegated_tooltip';
@@ -52,8 +59,8 @@ rl.ready(() => {
           icon.rel = 'tooltip';
           icon.title = `${seller} is on your Blocked Seller list.`;
 
-          name.closest('.shortcut_navigable').classList.add(_class);
-          name.closest('li').insertAdjacentElement('beforeend', icon);
+          name.closest(clazz).classList.add(_class);
+          name.closest(tag).insertAdjacentElement('beforeend', icon);
         }
       });
     });
@@ -75,7 +82,11 @@ rl.ready(() => {
 
         if ( rl.pageIs('allItems', 'seller', 'sellRelease', 'myWants') ) {
           type = 'hide';
-          window.blockSellers(type);
+          window.blockSellers(type, marketplaceQuerySelector, 'a', '.shortcut_navigable');
+
+        } else if ( rl.pageIs('messages') ) {
+          type = 'hide';
+          window.blockSellers(type, wantlistMessageQuerySelector, 'strong', '.wantlist-card');
         }
         break;
 
@@ -85,11 +96,11 @@ rl.ready(() => {
 
         if ( rl.pageIs('myWants') ) {
           type = 'hide';
-          window.blockSellers(type);
+          window.blockSellers(type, marketplaceQuerySelector, 'a', '.shortcut_navigable');
 
         } else if ( rl.pageIs('allItems', 'seller', 'sellRelease') ) {
           type = 'tag';
-          window.blockSellers(type);
+          window.blockSellers(type, wantlistMessageQuerySelector, 'strong', '.wantlist-card');
         }
         break;
 
@@ -99,12 +110,16 @@ rl.ready(() => {
 
         if ( rl.pageIs('allItems', 'seller', 'sellRelease', 'myWants') ) {
           type = 'tag';
-          window.blockSellers(type);
+          window.blockSellers(type, marketplaceQuerySelector, 'a', '.shortcut_navigable');
+
+        } else if ( rl.pageIs('messages') ) {
+          type = 'tag';
+          window.blockSellers(type, wantlistMessageQuerySelector, 'strong', '.wantlist-card');
         }
         break;
     }
 
-    rl.handlePaginationClicks(window.blockSellers, type);
+    rl.handlePaginationClicks(window.blockSellers, type, marketplaceQuerySelector, 'a', '.shortcut_navigable');
   }
 });
 /**


### PR DESCRIPTION
Besides the possibility to hide or block sellers on the Marketplace, you can also exclude them from Wantlist messages in the future. It's quite annoying when you open Wantlist messages and see these overpriced offers.