### PR TITLE
Marketplace Highlights fix

### DIFF
--- a/html/learn.html
+++ b/html/learn.html
@@ -938,7 +938,7 @@
         <li class="donor">Roman G.</li>
         <li class="donor">Rosalyn R.</li>
         <li>Salvatore C.</li>
-        <li class="donor">sdsowlsa <span style="color: #fff;">&#9733;</span></li>
+        <li class="donor">sdsowlsa <span style="color: #fff;">&#9733;</span><span style="color: #fff;">&#9733;</span></li>
         <li class="donor">Smithsix</li>
         <li>Sonny C.</li>
         <li class="donor">Stepan K.</li>

--- a/js/extension/features/marketplace-highlights.js
+++ b/js/extension/features/marketplace-highlights.js
@@ -18,7 +18,7 @@ rl.ready(() => {
 
     target.forEach(t => {
 
-      switch (t.textContent.trim()) {
+      switch (t.textContent.trim().split('\n')[0]) {
         case 'Mint (M)':
           t.className = 'mint bold';
           break;

--- a/js/popup/change-log.js
+++ b/js/popup/change-log.js
@@ -9,7 +9,7 @@ module.exports = {
           description: 'Dark theme updates for the new Skittles icons.'
         },
       ],
-      thanks: ['Huge thanks to @cyclistmusic for the donation!'],
+      thanks: ['Huge thanks to sdsowlsa for the donation! I really apprecaite it.'],
     },
   ],
   previous: [

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Discogs Enhancer",
   "short_name": "Discogs Enhancer",
   "description": "Adds a dark theme, block sellers, price comparisons, currency converter, configurable quick search, & more to Discogs!",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "author": "Matthew Salcido",
   "homepage_url": "https://www.discogs-enhancer.com",
   "action": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "discogs-enhancer",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discogs-enhancer",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "A Chrome extension that adds useful functionality to Discogs.com! https://www.discogs-enhancer.com",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Fixes an issue where MP media condition highlights were not being shown after changes to the tooltips were introduced by Discogs.

Massive shoutout to `sdsowlsa` for the donation! Thank you!